### PR TITLE
[BUGFIX] Phone number grammar should only allow a single instance of '*'/'x'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/benlangfeld/ruby_speech)
+  * Bugfix: Phone number grammar should only allow a single instance of '*'/'x'
 
 # [2.3.0](https://github.com/benlangfeld/ruby_speech/compare/v2.2.2...v2.3.0) - [2013-09-30](https://rubygems.org/gems/ruby_speech/versions/2.3.0)
   * Feature: Allow generation of a boolean, date, digits, currency, number, phone or time grammar including from URIs

--- a/lib/ruby_speech/grxml/builtins.rb
+++ b/lib/ruby_speech/grxml/builtins.rb
@@ -146,10 +146,19 @@ module RubySpeech::GRXML::Builtins
     RubySpeech::GRXML.draw mode: :dtmf, root: 'number' do
       rule id: 'number', scope: 'public' do
         item repeat: '1-' do
-          one_of do
-            0.upto(9) { |d| item { d.to_s } }
-            item { '*' }
+          ruleref uri: '#digit'
+        end
+        item repeat: '0-1' do
+          item { '*' }
+          item repeat: '0-' do
+            ruleref uri: '#digit'
           end
+        end
+      end
+
+      rule id: 'digit' do
+        one_of do
+          0.upto(9) { |d| item { d.to_s } }
         end
       end
     end

--- a/spec/ruby_speech/grxml/builtins_spec.rb
+++ b/spec/ruby_speech/grxml/builtins_spec.rb
@@ -143,11 +143,11 @@ describe RubySpeech::GRXML::Builtins do
     it { should match('0').and_interpret_as('dtmf-0') }
     it { should match('0123').and_interpret_as('dtmf-0 dtmf-1 dtmf-2 dtmf-3') }
     it { should match('0123*456').and_interpret_as('dtmf-0 dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-4 dtmf-5 dtmf-6') }
-    it { should match('0123*456*789').and_interpret_as('dtmf-0 dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-4 dtmf-5 dtmf-6 dtmf-star dtmf-7 dtmf-8 dtmf-9') }
 
     it { should potentially_match('') }
 
     it { should not_match('#') }
+    it { should not_match('0123*456*789') }
   end
 
   describe "time" do


### PR DESCRIPTION
By request of @vindir. Need to check this is valid as per specifications, but not sure which spec covers this. @sfgeorge?
