### PR TITLE
[BUG] Cloning an SSML document turns it into GRXML

### DIFF
--- a/spec/ruby_speech/ssml_spec.rb
+++ b/spec/ruby_speech/ssml_spec.rb
@@ -81,6 +81,30 @@ module RubySpeech
         SSML.draw { string foo }.should == expected_doc
       end
 
+      describe 'cloning' do
+        context 'SSML documents' do
+          let :original do
+            RubySpeech::SSML.draw do
+              string "Hi, I'm Fred."
+            end
+          end
+
+          subject { original.clone }
+
+          it 'should match the contents of the original document' do
+            subject.to_s.should == original.to_s
+          end
+
+          it 'should match the class of the original document' do
+            subject.class.should == original.class
+          end
+
+          it 'should be equal to the original document' do
+            subject.should == original
+          end
+        end
+      end
+
       describe "embedding" do
         it "SSML documents" do
           doc1 = RubySpeech::SSML.draw do


### PR DESCRIPTION
- Add a few tests to the test suite to reveal an issue with `GenericElement#clone`.  
  _Warning: Will cause test suite to fail._
- Does NOT include an actual fix for the tests.

Tests added:
- :white_check_mark: cloning SSML documents should match the contents of the original document
- :no_entry: cloning SSML documents should match the class of the original document
- :no_entry: cloning SSML documents should be equal to the original document
