### PR TITLE
[BUGFIX] allow cloned GenericElement to respect its own class

### DIFF
--- a/lib/ruby_speech/generic_element.rb
+++ b/lib/ruby_speech/generic_element.rb
@@ -176,7 +176,7 @@ module RubySpeech
     end
 
     def clone
-      GRXML.import to_xml
+      self.class.import to_xml
     end
 
     def traverse(&block)


### PR DESCRIPTION
Fixes bug where [SSML documents get converted to GRXML documents](https://github.com/benlangfeld/ruby_speech/issues/26)

Files affected: lib/ruby_speech/generic_element.rb
