### PR TITLE
Instance methods are not usable inside grammars

### DIFF
--- a/spec/ruby_speech/grxml_spec.rb
+++ b/spec/ruby_speech/grxml_spec.rb
@@ -69,19 +69,39 @@ module RubySpeech
         drawn_doc.should == expected_doc
       end
 
-      it "should allow accessing methods defined outside the block" do
-        def foo
-          'bar'
+      context 'accessing methods defined outside the block' do
+
+        it 'should be allowed at the top level' do
+          def foo
+            'bar'
+          end
+          drawn_doc = GRXML.draw do
+            rule id: foo
+          end
+
+          expected_doc = GRXML::Grammar.new doc
+          rule = GRXML::Rule.new(doc, id: foo)
+          expected_doc << rule
+          drawn_doc.should == expected_doc
         end
 
-        drawn_doc = GRXML.draw do
-          rule :id => foo
-        end
+        it 'should be allowed inside nested blocks' do
+          def foo
+            'bar'
+          end
+          drawn_doc = GRXML.draw do
+            rule id: 'root' do
+              item { foo }
+            end
+          end
 
-        expected_doc = GRXML::Grammar.new doc
-        rule = GRXML::Rule.new(doc, :id => foo)
-        expected_doc << rule
-        drawn_doc.should == expected_doc
+          expected_doc = GRXML::Grammar.new doc
+          rule = GRXML::Rule.new(doc, id: 'root')
+          item = GRXML::Item.new(doc, content: foo)
+          rule << item
+          expected_doc << rule
+          drawn_doc.should == expected_doc
+        end
       end
 
       it "should raise error if given an empty rule" do

--- a/spec/ruby_speech/ssml_spec.rb
+++ b/spec/ruby_speech/ssml_spec.rb
@@ -72,13 +72,32 @@ module RubySpeech
         drawn_doc.should == expected_doc
       end
 
-      it "should allow accessing methods defined outside the block" do
-        def foo
-          'bar'
+      context 'accessing methods defined outside the block' do
+        it 'should be allowed at the top level' do
+          def foo
+            'bar'
+          end
+
+          expected_doc = SSML::Speak.new doc, content: foo
+          SSML.draw { string foo }.should == expected_doc
         end
 
-        expected_doc = SSML::Speak.new doc, :content => foo
-        SSML.draw { string foo }.should == expected_doc
+        it 'should be allowed inside a nested block' do
+          def foo
+            'bar'
+          end
+
+          drawn_doc = SSML.draw do
+            phoneme alphabet: 'x-sampa', ph: 'b}r' do
+              string foo
+            end
+          end
+
+          expected_doc = SSML::Speak.new doc
+          phoneme = SSML::Phoneme.new doc, alphabet: 'x-sampa', ph: 'b}r', content: foo
+          expected_doc << phoneme
+          drawn_doc.should == expected_doc
+        end
       end
 
       describe 'cloning' do


### PR DESCRIPTION
It seems that when there is a method inside a class that returns a grammar, and that grammar uses the return values of other methods inside the class, RubySpeech throws an error.

Code looks like this: https://gist.github.com/wdrexler/f0b229d7dfb7a9629dbe
The error returned is:

```
/Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:277:in `method_missing': undefined local variable or method `my_method' for <item/>:RubySpeech::GRXML::Item (NameError)
    from ./rs_test.rb:14:in `block (3 levels) in grammar'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:126:in `instance_eval'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:126:in `eval_dsl_block'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:78:in `build'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:57:in `initialize'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:273:in `new'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:273:in `method_missing'
    from ./rs_test.rb:14:in `block (2 levels) in grammar'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:126:in `instance_eval'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:126:in `eval_dsl_block'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:78:in `build'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:57:in `initialize'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:273:in `new'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:273:in `method_missing'
    from ./rs_test.rb:13:in `block in grammar'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:126:in `instance_eval'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/generic_element.rb:126:in `eval_dsl_block'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/grxml.rb:25:in `block in draw'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/grxml.rb:23:in `tap'
    from /Users/wdrexler/.rvm/gems/ruby-2.1.2/bundler/gems/ruby_speech-a3a837c0106f/lib/ruby_speech/grxml.rb:23:in `draw'
    from ./rs_test.rb:12:in `grammar'
    from ./rs_test.rb:4:in `run'
    from ./rs_test.rb:20:in `<main>'
```

This error does not occur when either:
1. The methods are declared at the top level (i.e. outside of a class) or
2. If a local variable is assigned to the return value of the method before the `RubySpeech::GRXML.draw` block starts

This was tested against latest develop.
