### PR TITLE
Feature/more performant number grammar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ addons:
     - libpcre3-dev
 before_install:
   - gem install bundler
-before_script: export JRUBY_OPTS="--server -J-Xss1024k -J-Xmx652m -J-XX:+UseConcMarkSweepGC"
+before_script: export JRUBY_OPTS="--server --debug -J-Xss1024k -J-Xmx652m -J-XX:+UseConcMarkSweepGC"
 
 notifications:
   irc: "irc.freenode.org#adhearsion"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/benlangfeld/ruby_speech)
   * Feature: Permit percentage rate values for prosody tags
+  * Bugfix: Rulerefs referenced n-levels deep under Rulerefs should be expanded.
 
 # [2.3.2](https://github.com/benlangfeld/ruby_speech/compare/v2.3.1...v2.3.2) - [2014-04-21](https://rubygems.org/gems/ruby_speech/versions/2.3.2)
   * Bugfix: String nodes should take non-strings and cast to a string (`#to_s`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [develop](https://github.com/benlangfeld/ruby_speech)
   * Feature: Permit percentage rate values for prosody tags
   * Bugfix: Rulerefs referenced n-levels deep under Rulerefs should be expanded.
+  * Bugfix: Optimize performance of built-in number DTMF grammar
 
 # [2.3.2](https://github.com/benlangfeld/ruby_speech/compare/v2.3.1...v2.3.2) - [2014-04-21](https://rubygems.org/gems/ruby_speech/versions/2.3.2)
   * Bugfix: String nodes should take non-strings and cast to a string (`#to_s`)

--- a/lib/ruby_speech/grxml.rb
+++ b/lib/ruby_speech/grxml.rb
@@ -4,6 +4,7 @@ require 'ruby_speech/grxml/element'
 module RubySpeech
   module GRXML
     InvalidChildError = Class.new StandardError
+    MissingReferenceError = Class.new StandardError
 
     GRXML_NAMESPACE = 'http://www.w3.org/2001/06/grammar'
 

--- a/lib/ruby_speech/grxml.rb
+++ b/lib/ruby_speech/grxml.rb
@@ -5,6 +5,7 @@ module RubySpeech
   module GRXML
     InvalidChildError = Class.new StandardError
     MissingReferenceError = Class.new StandardError
+    ReferentialLoopError = Class.new StandardError
 
     GRXML_NAMESPACE = 'http://www.w3.org/2001/06/grammar'
 

--- a/lib/ruby_speech/grxml/builtins.rb
+++ b/lib/ruby_speech/grxml/builtins.rb
@@ -126,17 +126,26 @@ module RubySpeech::GRXML::Builtins
 
       rule id: 'less_than_one' do
         item { '*' }
-        item repeat: '1-' do
-          ruleref uri: '#digit'
+        item do
+          ruleref uri: '#digit_series'
         end
       end
 
       rule id: 'one_or_more' do
-        item repeat: '1-' do
-          ruleref uri: '#digit'
+        item do
+          ruleref uri: '#digit_series'
         end
         item repeat: '0-1' do
-          ruleref uri: '#less_than_one'
+          item { '*' }
+          item repeat: '0-1' do
+            ruleref uri: '#digit_series'
+          end
+        end
+      end
+
+      rule id: 'digit_series' do
+        item repeat: '1-' do
+          ruleref uri: '#digit'
         end
       end
 

--- a/lib/ruby_speech/grxml/builtins.rb
+++ b/lib/ruby_speech/grxml/builtins.rb
@@ -118,14 +118,28 @@ module RubySpeech::GRXML::Builtins
   def self.number(options = nil)
     RubySpeech::GRXML.draw mode: :dtmf, root: 'number' do
       rule id: 'number', scope: 'public' do
-        item repeat: '0-' do
+        one_of do
+          item { ruleref uri: '#less_than_one' }
+          item { ruleref uri: '#one_or_more' }
+        end
+      end
+
+      rule id: 'less_than_one' do
+        item { '*' }
+        item repeat: '1-' do
+          ruleref uri: '#digit'
+        end
+      end
+
+      rule id: 'one_or_more' do
+        item repeat: '1-' do
           ruleref uri: '#digit'
         end
         item repeat: '0-1' do
-          item { '*' }
-          item repeat: '0-' do
-            ruleref uri: '#digit'
-          end
+          '*'
+        end
+        item repeat: '0-' do
+          ruleref uri: '#digit'
         end
       end
 

--- a/lib/ruby_speech/grxml/builtins.rb
+++ b/lib/ruby_speech/grxml/builtins.rb
@@ -57,7 +57,7 @@ module RubySpeech::GRXML::Builtins
   # @option options [#to_i] :maxlength Maximum length for the string of digits.
   # @option options [#to_i] :length Absolute length for the string of digits.
   #
-  # @return [RubySpeech::GRXML::Grammar] a grammar for interpreting a boolean response.
+  # @return [RubySpeech::GRXML::Grammar] a grammar for interpreting an integer response.
   #
   # @raise [ArgumentError] if any of the length attributes logically conflict
   #

--- a/lib/ruby_speech/grxml/builtins.rb
+++ b/lib/ruby_speech/grxml/builtins.rb
@@ -136,10 +136,7 @@ module RubySpeech::GRXML::Builtins
           ruleref uri: '#digit'
         end
         item repeat: '0-1' do
-          '*'
-        end
-        item repeat: '0-' do
-          ruleref uri: '#digit'
+          ruleref uri: '#less_than_one'
         end
       end
 

--- a/lib/ruby_speech/grxml/builtins.rb
+++ b/lib/ruby_speech/grxml/builtins.rb
@@ -117,30 +117,30 @@ module RubySpeech::GRXML::Builtins
   # @return [RubySpeech::GRXML::Grammar] a grammar for interpreting a numeric value.
   #
   def self.number(options = nil)
-    RubySpeech::GRXML.draw mode: :dtmf, root: "number" do
-      rule id: "number", scope: "public" do
+    RubySpeech::GRXML.draw mode: :dtmf, root: 'number' do
+      rule id: 'number', scope: 'public' do
         one_of do
-          item { ruleref uri: "#less_than_one" }
-          item { ruleref uri: "#one_or_more" }
+          item { ruleref uri: '#less_than_one' }
+          item { ruleref uri: '#one_or_more' }
         end
       end
 
-      rule id: "less_than_one" do
-        item { "*" }
-        item { ruleref uri: "#digit_series" }
+      rule id: 'less_than_one' do
+        item { '*' }
+        item { ruleref uri: '#digit_series' }
       end
 
-      rule id: "one_or_more" do
-        item { ruleref uri: "#digit_series" }
-        item repeat: "0-1" do
-          item { "*" }
-          item(repeat: "0-1") { ruleref uri: "#digit_series" }
+      rule id: 'one_or_more' do
+        item { ruleref uri: '#digit_series' }
+        item repeat: '0-1' do
+          item { '*' }
+          item(repeat: '0-1') { ruleref uri: '#digit_series' }
         end
       end
 
-      rule(id: "digit_series") { item(repeat: "1-") { ruleref uri: "#digit" } }
+      rule(id: 'digit_series') { item(repeat: '1-') { ruleref uri: '#digit' } }
 
-      rule(id: "digit") { one_of { 0.upto(9) { |d| item { d.to_s } } } }
+      rule(id: 'digit') { one_of { 0.upto(9) { |d| item { d.to_s } } } }
     end
   end
 

--- a/lib/ruby_speech/grxml/builtins.rb
+++ b/lib/ruby_speech/grxml/builtins.rb
@@ -116,40 +116,40 @@ module RubySpeech::GRXML::Builtins
   # @return [RubySpeech::GRXML::Grammar] a grammar for interpreting a numeric value.
   #
   def self.number(options = nil)
-    RubySpeech::GRXML.draw mode: :dtmf, root: 'number' do
-      rule id: 'number', scope: 'public' do
+    RubySpeech::GRXML.draw mode: :dtmf, root: "number" do
+      rule id: "number", scope: "public" do
         one_of do
-          item { ruleref uri: '#less_than_one' }
-          item { ruleref uri: '#one_or_more' }
+          item { ruleref uri: "#less_than_one" }
+          item { ruleref uri: "#one_or_more" }
         end
       end
 
-      rule id: 'less_than_one' do
-        item { '*' }
+      rule id: "less_than_one" do
+        item { "*" }
         item do
-          ruleref uri: '#digit_series'
+          ruleref uri: "#digit_series"
         end
       end
 
-      rule id: 'one_or_more' do
+      rule id: "one_or_more" do
         item do
-          ruleref uri: '#digit_series'
+          ruleref uri: "#digit_series"
         end
-        item repeat: '0-1' do
-          item { '*' }
-          item repeat: '0-1' do
-            ruleref uri: '#digit_series'
+        item repeat: "0-1" do
+          item { "*" }
+          item repeat: "0-1" do
+            ruleref uri: "#digit_series"
           end
         end
       end
 
-      rule id: 'digit_series' do
-        item repeat: '1-' do
-          ruleref uri: '#digit'
+      rule id: "digit_series" do
+        item repeat: "1-" do
+          ruleref uri: "#digit"
         end
       end
 
-      rule id: 'digit' do
+      rule id: "digit" do
         one_of do
           0.upto(9) { |d| item { d.to_s } }
         end

--- a/lib/ruby_speech/grxml/builtins.rb
+++ b/lib/ruby_speech/grxml/builtins.rb
@@ -57,7 +57,8 @@ module RubySpeech::GRXML::Builtins
   # @option options [#to_i] :maxlength Maximum length for the string of digits.
   # @option options [#to_i] :length Absolute length for the string of digits.
   #
-  # @return [RubySpeech::GRXML::Grammar] a grammar for interpreting an integer response.
+  # @return [RubySpeech::GRXML::Grammar] a grammar for interpreting an integer
+  #                                      response.
   #
   # @raise [ArgumentError] if any of the length attributes logically conflict
   #
@@ -126,34 +127,20 @@ module RubySpeech::GRXML::Builtins
 
       rule id: "less_than_one" do
         item { "*" }
-        item do
-          ruleref uri: "#digit_series"
-        end
+        item { ruleref uri: "#digit_series" }
       end
 
       rule id: "one_or_more" do
-        item do
-          ruleref uri: "#digit_series"
-        end
+        item { ruleref uri: "#digit_series" }
         item repeat: "0-1" do
           item { "*" }
-          item repeat: "0-1" do
-            ruleref uri: "#digit_series"
-          end
+          item(repeat: "0-1") { ruleref uri: "#digit_series" }
         end
       end
 
-      rule id: "digit_series" do
-        item repeat: "1-" do
-          ruleref uri: "#digit"
-        end
-      end
+      rule(id: "digit_series") { item(repeat: "1-") { ruleref uri: "#digit" } }
 
-      rule id: "digit" do
-        one_of do
-          0.upto(9) { |d| item { d.to_s } }
-        end
-      end
+      rule(id: "digit") { one_of { 0.upto(9) { |d| item { d.to_s } } } }
     end
   end
 

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -116,9 +116,13 @@ module RubySpeech
       # @return self
       #
       def inline!
-        xpath("//ns:ruleref", :ns => GRXML_NAMESPACE).each do |ref|
-          rule = rule_with_id ref[:uri].sub(/^#/, '')
-          ref.swap rule.dup.children
+        loop do
+          rule = nil
+          xpath("//ns:ruleref", :ns => GRXML_NAMESPACE).each do |ref|
+            rule = rule_with_id ref[:uri].sub(/^#/, '')
+            ref.swap rule.dup.children
+          end
+          break unless rule
         end
 
         query = "./ns:rule[@id!='#{root}']"

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -120,6 +120,7 @@ module RubySpeech
           rule = nil
           xpath("//ns:ruleref", :ns => GRXML_NAMESPACE).each do |ref|
             rule = rule_with_id ref[:uri].sub(/^#/, '')
+            raise ArgumentError, "The Ruleref \"#{ref[:uri]}\" is referenced but not defined" unless rule
             ref.swap rule.dup.children
           end
           break unless rule

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -113,6 +113,9 @@ module RubySpeech
       # Replaces rulerefs in the document with a copy of the original rule.
       # Removes all top level rules except the root rule
       #
+      # @raises [MissingReferenceError] if a ruleref references a rule that is
+      #                                 not defined.
+      #
       # @return self
       #
       def inline!
@@ -121,8 +124,8 @@ module RubySpeech
           xpath('//ns:ruleref', ns: GRXML_NAMESPACE).each do |ref|
             rule = rule_with_id ref[:uri].sub(/^#/, '')
             unless rule
-              raise ArgumentError,
-                    "The Ruleref '#{ref[:uri]}' is referenced but not defined"
+              raise MissingReferenceError,
+                    "Ruleref '#{ref[:uri]}' is referenced but not defined"
             end
             ref.swap rule.dup.children
           end

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -118,9 +118,12 @@ module RubySpeech
       def inline!
         loop do
           rule = nil
-          xpath("//ns:ruleref", :ns => GRXML_NAMESPACE).each do |ref|
+          xpath("//ns:ruleref", ns: GRXML_NAMESPACE).each do |ref|
             rule = rule_with_id ref[:uri].sub(/^#/, '')
-            raise ArgumentError, "The Ruleref \"#{ref[:uri]}\" is referenced but not defined" unless rule
+            unless rule
+              raise ArgumentError,
+                "The Ruleref \"#{ref[:uri]}\" is referenced but not defined"
+            end
             ref.swap rule.dup.children
           end
           break unless rule

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -119,9 +119,10 @@ module RubySpeech
         loop do
           rule = nil
           xpath("//ns:ruleref", ns: GRXML_NAMESPACE).each do |ref|
-            rule = rule_with_id ref[:uri].sub(/^#/, '')
+            rule = rule_with_id ref[:uri].sub(/^#/, "")
             unless rule
-              raise ArgumentError,
+              raise
+                ArgumentError,
                 "The Ruleref \"#{ref[:uri]}\" is referenced but not defined"
             end
             ref.swap rule.dup.children

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -121,9 +121,8 @@ module RubySpeech
           xpath("//ns:ruleref", ns: GRXML_NAMESPACE).each do |ref|
             rule = rule_with_id ref[:uri].sub(/^#/, "")
             unless rule
-              raise
-                ArgumentError,
-                "The Ruleref \"#{ref[:uri]}\" is referenced but not defined"
+              raise ArgumentError,
+                    "The Ruleref \"#{ref[:uri]}\" is referenced but not defined"
             end
             ref.swap rule.dup.children
           end

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -118,11 +118,11 @@ module RubySpeech
       def inline!
         loop do
           rule = nil
-          xpath("//ns:ruleref", ns: GRXML_NAMESPACE).each do |ref|
-            rule = rule_with_id ref[:uri].sub(/^#/, "")
+          xpath('//ns:ruleref', ns: GRXML_NAMESPACE).each do |ref|
+            rule = rule_with_id ref[:uri].sub(/^#/, '')
             unless rule
               raise ArgumentError,
-                    "The Ruleref \"#{ref[:uri]}\" is referenced but not defined"
+                    "The Ruleref '#{ref[:uri]}' is referenced but not defined"
             end
             ref.swap rule.dup.children
           end

--- a/spec/ruby_speech/grxml/builtins_spec.rb
+++ b/spec/ruby_speech/grxml/builtins_spec.rb
@@ -134,7 +134,11 @@ describe RubySpeech::GRXML::Builtins do
     it { should match('123*').and_interpret_as('dtmf-1 dtmf-2 dtmf-3 dtmf-star') }
     it { should match('123*2342').and_interpret_as('dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-2 dtmf-3 dtmf-4 dtmf-2') }
 
+    it { should potentially_match('*') }
+
     it { should not_match('#') }
+    it { should not_match('**') }
+    it { should not_match('0123*456*789') }
   end
 
   describe "phone" do

--- a/spec/ruby_speech/grxml/builtins_spec.rb
+++ b/spec/ruby_speech/grxml/builtins_spec.rb
@@ -124,31 +124,19 @@ describe RubySpeech::GRXML::Builtins do
 
     it { should match("0").and_interpret_as "dtmf-0" }
     it { should match("123").and_interpret_as "dtmf-1 dtmf-2 dtmf-3" }
+    it { should match("1*01").and_interpret_as dtmf_seq %w(1 star 0 1) }
+    it { should match("01*00").and_interpret_as dtmf_seq %w(0 1 star 0 0) }
     it do
-      should match("1*01").and_interpret_as "dtmf-1 dtmf-star dtmf-0 dtmf-1"
+      should match("100000000000*00")
+        .and_interpret_as dtmf_seq %w(1 0 0 0 0 0 0 0 0 0 0 0 star 0 0)
     end
-    it do
-      should match("01*00").and_interpret_as(
-        %w(0 1 star 0 0).map { |d| "dtmf-#{d}" }.join " ")
-    end
-    it do
-      should match("100000000000*00").and_interpret_as(
-        %w(1 0 0 0 0 0 0 0 0 0 0 0 star 0 0).map { |d| "dtmf-#{d}" }.join " ")
-    end
-    it do
-      should match("0*08").and_interpret_as "dtmf-0 dtmf-star dtmf-0 dtmf-8"
-    end
+    it { should match("0*08").and_interpret_as dtmf_seq %w(0 star 0 8) }
     it { should match("*59").and_interpret_as "dtmf-star dtmf-5 dtmf-9" }
     it { should match("0*0").and_interpret_as "dtmf-0 dtmf-star dtmf-0" }
+    it { should match("10*5").and_interpret_as dtmf_seq %w(1 0 star 5) }
+    it { should match("123*").and_interpret_as dtmf_seq %w(1 2 3 star) }
     it do
-      should match("10*5").and_interpret_as "dtmf-1 dtmf-0 dtmf-star dtmf-5"
-    end
-    it do
-      should match("123*").and_interpret_as "dtmf-1 dtmf-2 dtmf-3 dtmf-star"
-    end
-    it do
-      should match("123*2342").and_interpret_as(
-        "dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-2 dtmf-3 dtmf-4 dtmf-2")
+      should match("123*2342").and_interpret_as dtmf_seq %w(1 2 3 star 2 3 4 2)
     end
 
     it { should potentially_match "*" }

--- a/spec/ruby_speech/grxml/builtins_spec.rb
+++ b/spec/ruby_speech/grxml/builtins_spec.rb
@@ -122,23 +122,40 @@ describe RubySpeech::GRXML::Builtins do
   describe "number" do
     subject(:grammar) { described_class.number }
 
-    it { should match("0").and_interpret_as("dtmf-0") }
-    it { should match("123").and_interpret_as("dtmf-1 dtmf-2 dtmf-3") }
-    it { should match("1*01").and_interpret_as("dtmf-1 dtmf-star dtmf-0 dtmf-1") }
-    it { should match("01*00").and_interpret_as("dtmf-0 dtmf-1 dtmf-star dtmf-0 dtmf-0") }
-    it { should match("100000000000*00").and_interpret_as("dtmf-1 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-star dtmf-0 dtmf-0") }
-    it { should match("0*08").and_interpret_as("dtmf-0 dtmf-star dtmf-0 dtmf-8") }
-    it { should match("*59").and_interpret_as("dtmf-star dtmf-5 dtmf-9") }
-    it { should match("0*0").and_interpret_as("dtmf-0 dtmf-star dtmf-0") }
-    it { should match("10*5").and_interpret_as("dtmf-1 dtmf-0 dtmf-star dtmf-5") }
-    it { should match("123*").and_interpret_as("dtmf-1 dtmf-2 dtmf-3 dtmf-star") }
-    it { should match("123*2342").and_interpret_as("dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-2 dtmf-3 dtmf-4 dtmf-2") }
+    it { should match("0").and_interpret_as "dtmf-0" }
+    it { should match("123").and_interpret_as "dtmf-1 dtmf-2 dtmf-3" }
+    it do
+      should match("1*01").and_interpret_as "dtmf-1 dtmf-star dtmf-0 dtmf-1"
+    end
+    it do
+      should match("01*00").and_interpret_as
+        %w(0 1 star 0 0).map { |d| "dtmf-#{d}" }.join " "
+    end
+    it do
+      should match("100000000000*00").and_interpret_as
+        %w(1 0 0 0 0 0 0 0 0 0 0 0 star 0 0).map { |d| "dtmf-#{d}" }.join " "
+    end
+    it do
+      should match("0*08").and_interpret_as "dtmf-0 dtmf-star dtmf-0 dtmf-8"
+    end
+    it { should match("*59").and_interpret_as "dtmf-star dtmf-5 dtmf-9" }
+    it { should match("0*0").and_interpret_as "dtmf-0 dtmf-star dtmf-0" }
+    it do
+      should match("10*5").and_interpret_as "dtmf-1 dtmf-0 dtmf-star dtmf-5"
+    end
+    it do
+      should match("123*").and_interpret_as "dtmf-1 dtmf-2 dtmf-3 dtmf-star"
+    end
+    it do
+      should match("123*2342").and_interpret_as
+        "dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-2 dtmf-3 dtmf-4 dtmf-2"
+    end
 
-    it { should potentially_match("*") }
+    it { should potentially_match "*" }
 
-    it { should not_match("#") }
-    it { should not_match("**") }
-    it { should not_match("0123*456*789") }
+    it { should not_match "#" }
+    it { should not_match "**" }
+    it { should not_match "0123*456*789" }
   end
 
   describe "phone" do

--- a/spec/ruby_speech/grxml/builtins_spec.rb
+++ b/spec/ruby_speech/grxml/builtins_spec.rb
@@ -128,12 +128,12 @@ describe RubySpeech::GRXML::Builtins do
       should match("1*01").and_interpret_as "dtmf-1 dtmf-star dtmf-0 dtmf-1"
     end
     it do
-      should match("01*00").and_interpret_as
-        %w(0 1 star 0 0).map { |d| "dtmf-#{d}" }.join " "
+      should match("01*00").and_interpret_as(
+        %w(0 1 star 0 0).map { |d| "dtmf-#{d}" }.join " ")
     end
     it do
-      should match("100000000000*00").and_interpret_as
-        %w(1 0 0 0 0 0 0 0 0 0 0 0 star 0 0).map { |d| "dtmf-#{d}" }.join " "
+      should match("100000000000*00").and_interpret_as(
+        %w(1 0 0 0 0 0 0 0 0 0 0 0 star 0 0).map { |d| "dtmf-#{d}" }.join " ")
     end
     it do
       should match("0*08").and_interpret_as "dtmf-0 dtmf-star dtmf-0 dtmf-8"
@@ -147,8 +147,8 @@ describe RubySpeech::GRXML::Builtins do
       should match("123*").and_interpret_as "dtmf-1 dtmf-2 dtmf-3 dtmf-star"
     end
     it do
-      should match("123*2342").and_interpret_as
-        "dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-2 dtmf-3 dtmf-4 dtmf-2"
+      should match("123*2342").and_interpret_as(
+        "dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-2 dtmf-3 dtmf-4 dtmf-2")
     end
 
     it { should potentially_match "*" }

--- a/spec/ruby_speech/grxml/builtins_spec.rb
+++ b/spec/ruby_speech/grxml/builtins_spec.rb
@@ -122,23 +122,23 @@ describe RubySpeech::GRXML::Builtins do
   describe "number" do
     subject(:grammar) { described_class.number }
 
-    it { should match('0').and_interpret_as('dtmf-0') }
-    it { should match('123').and_interpret_as('dtmf-1 dtmf-2 dtmf-3') }
-    it { should match('1*01').and_interpret_as('dtmf-1 dtmf-star dtmf-0 dtmf-1') }
-    it { should match('01*00').and_interpret_as('dtmf-0 dtmf-1 dtmf-star dtmf-0 dtmf-0') }
-    it { should match('100000000000*00').and_interpret_as('dtmf-1 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-star dtmf-0 dtmf-0') }
-    it { should match('0*08').and_interpret_as('dtmf-0 dtmf-star dtmf-0 dtmf-8') }
-    it { should match('*59').and_interpret_as('dtmf-star dtmf-5 dtmf-9') }
-    it { should match('0*0').and_interpret_as('dtmf-0 dtmf-star dtmf-0') }
-    it { should match('10*5').and_interpret_as('dtmf-1 dtmf-0 dtmf-star dtmf-5') }
-    it { should match('123*').and_interpret_as('dtmf-1 dtmf-2 dtmf-3 dtmf-star') }
-    it { should match('123*2342').and_interpret_as('dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-2 dtmf-3 dtmf-4 dtmf-2') }
+    it { should match("0").and_interpret_as("dtmf-0") }
+    it { should match("123").and_interpret_as("dtmf-1 dtmf-2 dtmf-3") }
+    it { should match("1*01").and_interpret_as("dtmf-1 dtmf-star dtmf-0 dtmf-1") }
+    it { should match("01*00").and_interpret_as("dtmf-0 dtmf-1 dtmf-star dtmf-0 dtmf-0") }
+    it { should match("100000000000*00").and_interpret_as("dtmf-1 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-0 dtmf-star dtmf-0 dtmf-0") }
+    it { should match("0*08").and_interpret_as("dtmf-0 dtmf-star dtmf-0 dtmf-8") }
+    it { should match("*59").and_interpret_as("dtmf-star dtmf-5 dtmf-9") }
+    it { should match("0*0").and_interpret_as("dtmf-0 dtmf-star dtmf-0") }
+    it { should match("10*5").and_interpret_as("dtmf-1 dtmf-0 dtmf-star dtmf-5") }
+    it { should match("123*").and_interpret_as("dtmf-1 dtmf-2 dtmf-3 dtmf-star") }
+    it { should match("123*2342").and_interpret_as("dtmf-1 dtmf-2 dtmf-3 dtmf-star dtmf-2 dtmf-3 dtmf-4 dtmf-2") }
 
-    it { should potentially_match('*') }
+    it { should potentially_match("*") }
 
-    it { should not_match('#') }
-    it { should not_match('**') }
-    it { should not_match('0123*456*789') }
+    it { should not_match("#") }
+    it { should not_match("**") }
+    it { should not_match("0123*456*789") }
   end
 
   describe "phone" do

--- a/spec/ruby_speech/grxml/builtins_spec.rb
+++ b/spec/ruby_speech/grxml/builtins_spec.rb
@@ -119,31 +119,31 @@ describe RubySpeech::GRXML::Builtins do
     it { should not_match('#') }
   end
 
-  describe "number" do
+  describe 'number' do
     subject(:grammar) { described_class.number }
 
-    it { should match("0").and_interpret_as "dtmf-0" }
-    it { should match("123").and_interpret_as "dtmf-1 dtmf-2 dtmf-3" }
-    it { should match("1*01").and_interpret_as dtmf_seq %w(1 star 0 1) }
-    it { should match("01*00").and_interpret_as dtmf_seq %w(0 1 star 0 0) }
+    it { should match('0').and_interpret_as 'dtmf-0' }
+    it { should match('123').and_interpret_as 'dtmf-1 dtmf-2 dtmf-3' }
+    it { should match('1*01').and_interpret_as dtmf_seq %w(1 star 0 1) }
+    it { should match('01*00').and_interpret_as dtmf_seq %w(0 1 star 0 0) }
     it do
-      should match("100000000000*00")
+      should match('100000000000*00')
         .and_interpret_as dtmf_seq %w(1 0 0 0 0 0 0 0 0 0 0 0 star 0 0)
     end
-    it { should match("0*08").and_interpret_as dtmf_seq %w(0 star 0 8) }
-    it { should match("*59").and_interpret_as "dtmf-star dtmf-5 dtmf-9" }
-    it { should match("0*0").and_interpret_as "dtmf-0 dtmf-star dtmf-0" }
-    it { should match("10*5").and_interpret_as dtmf_seq %w(1 0 star 5) }
-    it { should match("123*").and_interpret_as dtmf_seq %w(1 2 3 star) }
+    it { should match('0*08').and_interpret_as dtmf_seq %w(0 star 0 8) }
+    it { should match('*59').and_interpret_as 'dtmf-star dtmf-5 dtmf-9' }
+    it { should match('0*0').and_interpret_as 'dtmf-0 dtmf-star dtmf-0' }
+    it { should match('10*5').and_interpret_as dtmf_seq %w(1 0 star 5) }
+    it { should match('123*').and_interpret_as dtmf_seq %w(1 2 3 star) }
     it do
-      should match("123*2342").and_interpret_as dtmf_seq %w(1 2 3 star 2 3 4 2)
+      should match('123*2342').and_interpret_as dtmf_seq %w(1 2 3 star 2 3 4 2)
     end
 
-    it { should potentially_match "*" }
+    it { should potentially_match '*' }
 
-    it { should not_match "#" }
-    it { should not_match "**" }
-    it { should not_match "0123*456*789" }
+    it { should not_match '#' }
+    it { should not_match '**' }
+    it { should not_match '0123*456*789' }
   end
 
   describe "phone" do

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -310,6 +310,20 @@ module RubySpeech
 
             pending 'should raise an Exception'
           end
+
+          context 'with an invalid-reference' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#lost'
+                end
+              end.inline
+            end
+
+            it 'should raise a descriptive exception' do
+              expect { subject }.to raise_error ArgumentError, 'The Ruleref "#lost" is referenced but not defined'
+            end
+          end
         end
       end
 

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -232,6 +232,70 @@ module RubySpeech
           grammar.inline!.should == inline_grammar
           grammar.should == inline_grammar
         end
+
+        context 'nested' do
+          let :expected_doc do
+            RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+              rule :id => :main, :scope => 'public' do
+                string "How about an oatmeal cookie?  You'll feel better."
+              end
+            end
+          end
+
+          context '1 level deep' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#rabbit_hole2'
+                end
+                rule id: 'rabbit_hole2' do
+                  string "How about an oatmeal cookie?  You'll feel better."
+                end
+              end.inline
+            end
+
+            it { should eq expected_doc }
+          end
+
+          context '2 levels deep' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#rabbit_hole2'
+                end
+                rule id: 'rabbit_hole2' do
+                  ruleref uri: '#rabbit_hole3'
+                end
+                rule id: 'rabbit_hole3' do
+                  string "How about an oatmeal cookie?  You'll feel better."
+                end
+              end.inline
+            end
+
+            it { should eq expected_doc }
+          end
+
+          context '3 levels deep' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#rabbit_hole2'
+                end
+                rule id: 'rabbit_hole2' do
+                  ruleref uri: '#rabbit_hole3'
+                end
+                rule id: 'rabbit_hole3' do
+                  ruleref uri: '#rabbit_hole4'
+                end
+                rule id: 'rabbit_hole4' do
+                  string "How about an oatmeal cookie?  You'll feel better."
+                end
+              end.inline
+            end
+
+            it { should eq expected_doc }
+          end
+        end
       end
 
       describe "#tokenize!" do

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -295,6 +295,21 @@ module RubySpeech
 
             it { should eq expected_doc }
           end
+
+          context 'in a self-referencial infinite loop' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#paradox'
+                end
+                rule id: 'paradox' do
+                  ruleref uri: '#paradox'
+                end
+              end.inline
+            end
+
+            pending 'should raise an Exception'
+          end
         end
       end
 

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -308,7 +308,46 @@ module RubySpeech
               end.inline
             end
 
-            pending 'should raise an Exception'
+            it 'should raise an Exception' do
+              expect { subject }
+                .to raise_error RubySpeech::GRXML::ReferentialLoopError
+            end
+          end
+
+          context 'in a cross-referencial infinite loop' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule id: :main, scope: 'public' do
+                  ruleref uri: '#007'
+                end
+                rule id: '007' do
+                  one_of do
+                    item do
+                      ruleref uri: '#bond'
+                    end
+                  end
+                end
+                rule id: 'bond' do
+                  one_of do
+                    item do
+                      ruleref uri: '#james_bond'
+                    end
+                  end
+                end
+                rule id: 'james_bond' do
+                  one_of do
+                    item do
+                      ruleref uri: '#007'
+                    end
+                  end
+                end
+              end.inline
+            end
+
+            it 'should raise an Exception' do
+              expect { subject }
+                .to raise_error RubySpeech::GRXML::ReferentialLoopError
+            end
           end
 
           context 'with an invalid-reference' do

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -233,22 +233,22 @@ module RubySpeech
           grammar.should == inline_grammar
         end
 
-        context 'nested' do
+        context "nested" do
           let :expected_doc do
-            RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-              rule :id => :main, :scope => 'public' do
+            RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
+              rule id: :main, scope: "public" do
                 string "How about an oatmeal cookie?  You'll feel better."
               end
             end
           end
 
-          context '1 level deep' do
+          context "1 level deep" do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
-                  ruleref uri: '#rabbit_hole2'
+              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
+                rule id: :main, scope: "public" do
+                  ruleref uri: "#rabbit_hole2"
                 end
-                rule id: 'rabbit_hole2' do
+                rule id: "rabbit_hole2" do
                   string "How about an oatmeal cookie?  You'll feel better."
                 end
               end.inline
@@ -257,16 +257,16 @@ module RubySpeech
             it { should eq expected_doc }
           end
 
-          context '2 levels deep' do
+          context "2 levels deep" do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
-                  ruleref uri: '#rabbit_hole2'
+              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
+                rule id: :main, scope: "public" do
+                  ruleref uri: "#rabbit_hole2"
                 end
-                rule id: 'rabbit_hole2' do
-                  ruleref uri: '#rabbit_hole3'
+                rule id: "rabbit_hole2" do
+                  ruleref uri: "#rabbit_hole3"
                 end
-                rule id: 'rabbit_hole3' do
+                rule id: "rabbit_hole3" do
                   string "How about an oatmeal cookie?  You'll feel better."
                 end
               end.inline
@@ -275,19 +275,19 @@ module RubySpeech
             it { should eq expected_doc }
           end
 
-          context '3 levels deep' do
+          context "3 levels deep" do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
-                  ruleref uri: '#rabbit_hole2'
+              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
+                rule id: :main, scope: "public" do
+                  ruleref uri: "#rabbit_hole2"
                 end
-                rule id: 'rabbit_hole2' do
-                  ruleref uri: '#rabbit_hole3'
+                rule id: "rabbit_hole2" do
+                  ruleref uri: "#rabbit_hole3"
                 end
-                rule id: 'rabbit_hole3' do
-                  ruleref uri: '#rabbit_hole4'
+                rule id: "rabbit_hole3" do
+                  ruleref uri: "#rabbit_hole4"
                 end
-                rule id: 'rabbit_hole4' do
+                rule id: "rabbit_hole4" do
                   string "How about an oatmeal cookie?  You'll feel better."
                 end
               end.inline
@@ -296,32 +296,33 @@ module RubySpeech
             it { should eq expected_doc }
           end
 
-          context 'in a self-referencial infinite loop' do
+          context "in a self-referencial infinite loop" do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
-                  ruleref uri: '#paradox'
+              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
+                rule id: :main, scope: "public" do
+                  ruleref uri: "#paradox"
                 end
-                rule id: 'paradox' do
-                  ruleref uri: '#paradox'
+                rule id: "paradox" do
+                  ruleref uri: "#paradox"
                 end
               end.inline
             end
 
-            pending 'should raise an Exception'
+            pending "should raise an Exception"
           end
 
-          context 'with an invalid-reference' do
+          context "with an invalid-reference" do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
-                  ruleref uri: '#lost'
+              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
+                rule id: :main, scope: "public" do
+                  ruleref uri: "#lost"
                 end
               end.inline
             end
 
-            it 'should raise a descriptive exception' do
-              expect { subject }.to raise_error ArgumentError, 'The Ruleref "#lost" is referenced but not defined'
+            it "should raise a descriptive exception" do
+              expect { subject }.to raise_error ArgumentError,
+                'The Ruleref "#lost" is referenced but not defined'
             end
           end
         end

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -321,8 +321,7 @@ module RubySpeech
             end
 
             it "should raise a descriptive exception" do
-              expect { subject }.to
-                raise_error ArgumentError,
+              expect { subject }.to raise_error ArgumentError,
                 'The Ruleref "#lost" is referenced but not defined'
             end
           end

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -321,8 +321,8 @@ module RubySpeech
             end
 
             it "should raise a descriptive exception" do
-              expect { subject }.to raise_error ArgumentError,
-                'The Ruleref "#lost" is referenced but not defined'
+              message = 'The Ruleref "#lost" is referenced but not defined'
+              expect { subject }.to raise_error ArgumentError, message
             end
           end
         end

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -321,8 +321,9 @@ module RubySpeech
             end
 
             it 'should raise a descriptive exception' do
-              message = "The Ruleref '#lost' is referenced but not defined"
-              expect { subject }.to raise_error ArgumentError, message
+              expect { subject }
+                .to raise_error RubySpeech::GRXML::MissingReferenceError,
+                                "Ruleref '#lost' is referenced but not defined"
             end
           end
         end

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -233,22 +233,22 @@ module RubySpeech
           grammar.should == inline_grammar
         end
 
-        context "nested" do
+        context 'nested' do
           let :expected_doc do
-            RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
-              rule id: :main, scope: "public" do
+            RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+              rule id: :main, scope: 'public' do
                 string "How about an oatmeal cookie?  You'll feel better."
               end
             end
           end
 
-          context "1 level deep" do
+          context '1 level deep' do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
-                rule id: :main, scope: "public" do
-                  ruleref uri: "#rabbit_hole2"
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule id: :main, scope: 'public' do
+                  ruleref uri: '#rabbit_hole2'
                 end
-                rule id: "rabbit_hole2" do
+                rule id: 'rabbit_hole2' do
                   string "How about an oatmeal cookie?  You'll feel better."
                 end
               end.inline
@@ -257,16 +257,16 @@ module RubySpeech
             it { should eq expected_doc }
           end
 
-          context "2 levels deep" do
+          context '2 levels deep' do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
-                rule id: :main, scope: "public" do
-                  ruleref uri: "#rabbit_hole2"
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule id: :main, scope: 'public' do
+                  ruleref uri: '#rabbit_hole2'
                 end
-                rule id: "rabbit_hole2" do
-                  ruleref uri: "#rabbit_hole3"
+                rule id: 'rabbit_hole2' do
+                  ruleref uri: '#rabbit_hole3'
                 end
-                rule id: "rabbit_hole3" do
+                rule id: 'rabbit_hole3' do
                   string "How about an oatmeal cookie?  You'll feel better."
                 end
               end.inline
@@ -275,19 +275,19 @@ module RubySpeech
             it { should eq expected_doc }
           end
 
-          context "3 levels deep" do
+          context '3 levels deep' do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
-                rule id: :main, scope: "public" do
-                  ruleref uri: "#rabbit_hole2"
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule id: :main, scope: 'public' do
+                  ruleref uri: '#rabbit_hole2'
                 end
-                rule id: "rabbit_hole2" do
-                  ruleref uri: "#rabbit_hole3"
+                rule id: 'rabbit_hole2' do
+                  ruleref uri: '#rabbit_hole3'
                 end
-                rule id: "rabbit_hole3" do
-                  ruleref uri: "#rabbit_hole4"
+                rule id: 'rabbit_hole3' do
+                  ruleref uri: '#rabbit_hole4'
                 end
-                rule id: "rabbit_hole4" do
+                rule id: 'rabbit_hole4' do
                   string "How about an oatmeal cookie?  You'll feel better."
                 end
               end.inline
@@ -296,32 +296,32 @@ module RubySpeech
             it { should eq expected_doc }
           end
 
-          context "in a self-referencial infinite loop" do
+          context 'in a self-referencial infinite loop' do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
-                rule id: :main, scope: "public" do
-                  ruleref uri: "#paradox"
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule id: :main, scope: 'public' do
+                  ruleref uri: '#paradox'
                 end
-                rule id: "paradox" do
-                  ruleref uri: "#paradox"
+                rule id: 'paradox' do
+                  ruleref uri: '#paradox'
                 end
               end.inline
             end
 
-            pending "should raise an Exception"
+            pending 'should raise an Exception'
           end
 
-          context "with an invalid-reference" do
+          context 'with an invalid-reference' do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
-                rule id: :main, scope: "public" do
-                  ruleref uri: "#lost"
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule id: :main, scope: 'public' do
+                  ruleref uri: '#lost'
                 end
               end.inline
             end
 
-            it "should raise a descriptive exception" do
-              message = 'The Ruleref "#lost" is referenced but not defined'
+            it 'should raise a descriptive exception' do
+              message = "The Ruleref '#lost' is referenced but not defined"
               expect { subject }.to raise_error ArgumentError, message
             end
           end

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -321,7 +321,8 @@ module RubySpeech
             end
 
             it "should raise a descriptive exception" do
-              expect { subject }.to raise_error ArgumentError,
+              expect { subject }.to
+                raise_error ArgumentError,
                 'The Ruleref "#lost" is referenced but not defined'
             end
           end

--- a/spec/support/dtmf_helper.rb
+++ b/spec/support/dtmf_helper.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 #
 # Convert a simple DTMF string from "1 star 2" to "dtmf-1 dtmf-star dtmf-2".

--- a/spec/support/dtmf_helper.rb
+++ b/spec/support/dtmf_helper.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+#
+# Convert a simple DTMF string from "1 star 2" to "dtmf-1 dtmf-star dtmf-2".
+#
+# @param [Array] sequence A set of DTMF keys, such as `%w(1 star 2)`.
+#
+# @return [String] A string with "dtmf-" prefixed for each DTMF element.
+#                  Example: "dtmf-1 dtmf-star dtmf-2".
+#
+def dtmf_seq(sequence)
+  sequence.map { |d| "dtmf-#{d}" }.join " "
+end

--- a/spec/support/dtmf_helper.rb
+++ b/spec/support/dtmf_helper.rb
@@ -9,5 +9,5 @@
 #                  Example: "dtmf-1 dtmf-star dtmf-2".
 #
 def dtmf_seq(sequence)
-  sequence.map { |d| "dtmf-#{d}" }.join " "
+  sequence.map { |d| "dtmf-#{d}" }.join ' '
 end


### PR DESCRIPTION
Make the number DTMF grammar more performant for LumenVox.  Note that the more re-use we employ with rulerefs, the fewer cycles that their FST has to create.

Opening this for peer review along with the open source community.