### PR TITLE
[SPEC] Forego simplecov-html reporting to ensure Coveralls posts

### DIFF
--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<guard-rake>, [">= 0"]
   s.add_development_dependency %q<rake-compiler>, [">= 0"]
   s.add_development_dependency %q<coveralls>, [">= 0"]
-  s.add_development_dependency %q<simplecov>, [">= 0"]
 
   if RUBY_VERSION < '2.0'
     s.add_development_dependency %q<term-ansicolor>, ["< 1.3.1"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,8 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-%w{
-  simplecov
-  coveralls
-}.each { |f| require f }
-
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
-SimpleCov.start
+require "coveralls"
+Coveralls.wear!
 
 %w{
   rspec/its


### PR DESCRIPTION
I'm currently stumped on trying to get both simplecov-html and Coveralls to play nicely together, despite documentation that leads one to believe that they are best friends.

For the time being, I'm giving up on my recent attempt to introduce simplecov-html.  It's more important to ensure that the CI-based code coverage is restored and continues to work.