### PR TITLE
Rename from benlangfeld to adhearsion/ruby_speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Gem Version](https://badge.fury.io/rb/ruby_speech.png)](https://rubygems.org/gems/ruby_speech)
 [![Build Status](https://secure.travis-ci.org/adhearsion/ruby_speech.png?branch=develop)](http://travis-ci.org/adhearsion/ruby_speech)
 [![Dependency Status](https://gemnasium.com/adhearsion/ruby_speech.png?travis)](https://gemnasium.com/adhearsion/ruby_speech)
-[![Code Climate](https://codeclimate.com/github/benlangfeld/ruby_speech.png)](https://codeclimate.com/github/benlangfeld/ruby_speech)
+[![Code Climate](https://codeclimate.com/github/adhearsion/ruby_speech.png)](https://codeclimate.com/github/adhearsion/ruby_speech)
 [![Coverage Status](https://coveralls.io/repos/adhearsion/ruby_speech/badge.png?branch=develop)](https://coveralls.io/r/adhearsion/ruby_speech)
 
 # RubySpeech

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Gem Version](https://badge.fury.io/rb/ruby_speech.png)](https://rubygems.org/gems/ruby_speech)
-[![Build Status](https://secure.travis-ci.org/benlangfeld/ruby_speech.png?branch=develop)](http://travis-ci.org/benlangfeld/ruby_speech)
-[![Dependency Status](https://gemnasium.com/benlangfeld/ruby_speech.png?travis)](https://gemnasium.com/benlangfeld/ruby_speech)
+[![Build Status](https://secure.travis-ci.org/adhearsion/ruby_speech.png?branch=develop)](http://travis-ci.org/adhearsion/ruby_speech)
+[![Dependency Status](https://gemnasium.com/adhearsion/ruby_speech.png?travis)](https://gemnasium.com/adhearsion/ruby_speech)
 [![Code Climate](https://codeclimate.com/github/benlangfeld/ruby_speech.png)](https://codeclimate.com/github/benlangfeld/ruby_speech)
-[![Coverage Status](https://coveralls.io/repos/benlangfeld/ruby_speech/badge.png?branch=develop)](https://coveralls.io/r/benlangfeld/ruby_speech)
+[![Coverage Status](https://coveralls.io/repos/adhearsion/ruby_speech/badge.png?branch=develop)](https://coveralls.io/r/adhearsion/ruby_speech)
 
 # RubySpeech
 RubySpeech is a library for constructing and parsing Text to Speech (TTS) and Automatic Speech Recognition (ASR) documents such as [SSML](http://www.w3.org/TR/speech-synthesis), [GRXML](http://www.w3.org/TR/speech-grammar/) and [NLSML](http://www.w3.org/TR/nl-spec/). Such documents can be constructed to be processed by TTS and ASR engines, parsed as the result from such, or used in the implementation of such engines.
@@ -331,7 +331,7 @@ document.best_interpretation # => {
         }
 ```
 
-Check out the [YARD documentation](http://rdoc.info/github/benlangfeld/ruby_speech/master/frames) for more
+Check out the [YARD documentation](http://rdoc.info/github/adhearsion/ruby_speech/master/frames) for more
 
 ## Features:
 ### SSML
@@ -374,10 +374,10 @@ Check out the [YARD documentation](http://rdoc.info/github/benlangfeld/ruby_spee
 * `<lexicon/>`
 
 ## Links:
-* [Source](https://github.com/benlangfeld/ruby_speech)
+* [Source](https://github.com/adhearsion/ruby_speech)
 * [Documentation](http://rdoc.info/gems/ruby_speech/frames)
-* [Bug Tracker](https://github.com/benlangfeld/ruby_speech/issues)
-* [CI](https://travis-ci.org/#!/benlangfeld/ruby_speech)
+* [Bug Tracker](https://github.com/adhearsion/ruby_speech/issues)
+* [CI](https://travis-ci.org/#!/adhearsion/ruby_speech)
 
 ## Note on Patches/Pull Requests
 

--- a/ext/ruby_speech/RubySpeechGRXMLMatcher.java
+++ b/ext/ruby_speech/RubySpeechGRXMLMatcher.java
@@ -1,4 +1,4 @@
-package com.benlangfeld.ruby_speech;
+package com.adhearsion.ruby_speech;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;

--- a/ext/ruby_speech/RubySpeechService.java
+++ b/ext/ruby_speech/RubySpeechService.java
@@ -1,4 +1,4 @@
-package com.benlangfeld.ruby_speech;
+package com.adhearsion.ruby_speech;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;

--- a/ext/ruby_speech/extconf.rb
+++ b/ext/ruby_speech/extconf.rb
@@ -3,7 +3,7 @@ require 'mkmf'
 $LIBS << " -lpcre"
 
 unless find_header('pcre.h')
-  abort "-----\nPCRE is missing. You must install it as per the README @ https://github.com/benlangfeld/ruby_speech\n-----"
+  abort "-----\nPCRE is missing. You must install it as per the README @ https://github.com/adhearsion/ruby_speech\n-----"
 end
 
 create_makefile 'ruby_speech/ruby_speech'

--- a/lib/ruby_speech/grxml/matcher.rb
+++ b/lib/ruby_speech/grxml/matcher.rb
@@ -6,7 +6,7 @@ require 'ruby_speech/ruby_speech'
 
 if RUBY_PLATFORM =~ /java/
   require 'jruby'
-  com.benlangfeld.ruby_speech.RubySpeechService.new.basicLoad(JRuby.runtime)
+  com.adhearsion.ruby_speech.RubySpeechService.new.basicLoad(JRuby.runtime)
 end
 
 module RubySpeech

--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = RubySpeech::VERSION
   s.authors     = ["Ben Langfeld"]
   s.email       = ["ben@langfeld.me"]
-  s.homepage    = "https://github.com/benlangfeld/ruby_speech"
+  s.homepage    = "https://github.com/adhearsion/ruby_speech"
   s.summary     = %q{A Ruby library for TTS & ASR document preparation}
   s.description = %q{Prepare SSML and GRXML documents with ease}
 


### PR DESCRIPTION
Not important, just mainly for URLs that don't support aliases/renames as well as github does.