### PR TITLE
[BUGFIX] Fix handling of millisecond values (#48)

### DIFF
--- a/lib/ruby_speech/ssml/break.rb
+++ b/lib/ruby_speech/ssml/break.rb
@@ -36,7 +36,7 @@ module RubySpeech
       # @return [Float]
       #
       def time
-        read_attr :time, :to_f
+        get_time_attribute :time
       end
 
       ##

--- a/lib/ruby_speech/ssml/element.rb
+++ b/lib/ruby_speech/ssml/element.rb
@@ -23,9 +23,21 @@ module RubySpeech
 
       private
 
+      def get_time_attribute(key)
+        value = read_attr(key)
+
+        if value.nil?
+          nil
+        elsif value.end_with?('ms')
+          value.to_f / 1000
+        else
+          value.to_f
+        end
+      end
+
       def set_time_attribute(key, value)
         raise ArgumentError, "You must specify a valid #{key} (positive float value in seconds)" unless value.is_a?(Numeric) && value >= 0
-        self[key] = "#{value}s"
+        self[key] = value == value.round ? "#{value.to_i}s" : "#{(value * 1000).to_i}ms"
       end
     end # Element
   end # SSML

--- a/lib/ruby_speech/ssml/prosody.rb
+++ b/lib/ruby_speech/ssml/prosody.rb
@@ -134,7 +134,8 @@ module RubySpeech
       # @return [Integer]
       #
       def duration
-        read_attr :duration, :to_i
+        value = get_time_attribute :duration
+        value.round if value
       end
 
       ##

--- a/spec/ruby_speech/ssml/break_spec.rb
+++ b/spec/ruby_speech/ssml/break_spec.rb
@@ -21,14 +21,28 @@ module RubySpeech
       end
 
       describe "from a document" do
-        let(:document) { '<break strength="strong" time="3"/>' }
-
         subject { Element.import document }
 
-        it { should be_instance_of Break }
+        context 'with time of 3' do
+          let(:document) { '<break strength="strong" time="3"/>' }
 
-        its(:strength)  { should == :strong }
-        its(:time)      { should == 3 }
+          it { should be_instance_of Break }
+
+          its(:strength)  { should == :strong }
+          its(:time)      { should eql 3.0 }
+        end
+
+        context 'with time of 4s' do
+          let(:document) { '<break time="4s"/>' }
+
+          its(:time)      { should eql 4.0 }
+        end
+
+        context 'with time of 5555ms' do
+          let(:document) { '<break time="5555ms"/>' }
+
+          its(:time)      { should eql 5.555 }
+        end
       end
 
       describe "#strength" do
@@ -51,10 +65,16 @@ module RubySpeech
       end
 
       describe "#time" do
-        context "with a valid value" do
+        context "with a valid whole seconds value of 3" do
           before { subject.time = 3 }
 
-          its(:time) { should == 3 }
+          its(:time) { should eql 3.0 }
+        end
+
+        context "with a valid fractional seconds value of 3.5" do
+          before { subject.time = 3.5 }
+
+          its(:time) { should eql 3.5 }
         end
 
         context "with a negative value" do

--- a/spec/ruby_speech/ssml/prosody_spec.rb
+++ b/spec/ruby_speech/ssml/prosody_spec.rb
@@ -16,7 +16,7 @@ module RubySpeech
         its(:contour)   { should == 'something' }
         its(:range)     { should == '20Hz' }
         its(:rate)      { should == 2 }
-        its(:duration)  { should == 10 }
+        its(:duration)  { should eql 10 }
         its(:volume)    { should == :loud }
       end
 
@@ -35,7 +35,7 @@ module RubySpeech
         its(:contour)   { should == 'something' }
         its(:range)     { should == '20Hz' }
         its(:rate)      { should == 2 }
-        its(:duration)  { should == 10 }
+        its(:duration)  { should eql 10 }
         its(:volume)    { should == :loud }
       end
 
@@ -174,7 +174,7 @@ module RubySpeech
         context "with a valid value" do
           before { subject.duration = 3 }
 
-          its(:duration) { should == 3 }
+          its(:duration) { should eql 3 }
         end
 
         context "with a negative value" do


### PR DESCRIPTION
When trying an SSML Break time of 0.5 under Adhearsion, FreeSWITCH
treats this as 0 seconds. This makes some sense as the spec does not
say that you can pass fractional seconds, only whole seconds or
milliseconds with the appropriate suffix.

This change adds the appropriate suffix when rendering XML and
converts back to seconds again when reading XML.