### PR TITLE
Bump to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [develop](https://github.com/benlangfeld/ruby_speech)
+
+# [3.0.0](https://github.com/benlangfeld/ruby_speech/compare/v2.4.0...v3.0.0) - [2018-07-10](https://rubygems.org/gems/ruby_speech/versions/3.0.0)
   * Feature: Loosen and bump Nokogiri version to ~>1.8, >=1.8.3
   * Feature: Bump RSpec to 3.x and convert specs with Transpec
 

--- a/lib/ruby_speech/version.rb
+++ b/lib/ruby_speech/version.rb
@@ -1,3 +1,3 @@
 module RubySpeech
-  VERSION = "2.4.0"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
This is a major version change due to dropping older Ruby versions.