### PR TITLE
Gemspec: Drop deprecated and ignored property

### DIFF
--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.rubyforge_project = "ruby_speech"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

RubyForge was closed down in 2013 [1]. The `rubyforge_project` property
was deprecated in rubygems in pull request 2436 [2].

[1] https://twitter.com/evanphx/status/399552820380053505
[2] rubygems/rubygems#2436