### PR TITLE
CI: Separate out Rubinius to use Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,16 @@ rvm:
   - 2.6.3
   - jruby-9.1.17.0
   - jruby-head
-  - rbx-3
   - ruby-head
 jdk:
   - openjdk8 # for jruby
 matrix:
+  include:
+    - rvm: rbx-4
+      dist: trusty
+      name: Rubinius
   allow_failures:
-    - rvm: rbx-3
+    - name: Rubinius
     - rvm: ruby-head
 addons:
   apt:


### PR DESCRIPTION
This PR extracts `rbx-3` and turns it into `rbx-4` on Trusty. (That's the only `dist` on Travis which even starts `rbx` things.)